### PR TITLE
remove scrollback.io and other cruft

### DIFF
--- a/templates/_footer.mustache
+++ b/templates/_footer.mustache
@@ -5,117 +5,25 @@
 <p>Source: <a href=https://github.com/hackerspacesg/hackerspace.sg>On Github</a></p>
 </footer>
 
-
-<script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
+<script src="//ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
 <script src="/js/bootstrap.min.js"></script>
-<script src="/js/davis.min.js"></script>
 <script src="/js/moment.min.js"></script>
+
 <script>
-var app;
-var formatTimes = function(){
+$(document).ready(function() {
   $('time').each(function(index){
     d = moment($(this).attr('datetime'));
     $(this).text(d.fromNow() + ' at ' + d.format('h:mma'));
   });
-}
-var updateHeader = function(path)
-{
-  var class_name = (path == '/') ? 'home' : 'sub-page';
-  $('body').removeClass().addClass(class_name);
-}
-var scrollToPosition = function(pos){
-  $('body').animate({scrollTop:pos},200);
-}
-var scrollToElement = function(el){
-  var pos = $(el).offset().top;
-  scrollToPosition(parseInt(pos) - 56);
-}
-var fetchPage = function(path){
-  updateHeader(path);
-  var hasCallback = false;
-  if (arguments.length > 1){
-    hasCallback = true;
-    var callback = arguments[1];
-  }
-  $('div.content-wrapper').load(path + " div.container", function(){
-    formatTimes();
-    _gaq.push(['_trackPageview', path]);
-    if (hasCallback){
-      callback();
-    } else {
-      scrollToPosition(0);
-    }
-  });
-  return false;
-}
-$(document).ready(function(){
-  app = Davis(function () {
-    this.before(function (req) {
-      if ($('button.navbar-toggle').css('display') != 'none')
-      {
-        $('#subpages-navbar').collapse('hide');
-      }
-    })
-    this.get('/', function (req) {
-      fetchPage("/");
-      return false;
-    })
-    this.get('/?', function (req) {
-      return false;
-    })
-    this.get('/:path', function (req) {
-      var pathStr = req.location();
-      if (pathStr.indexOf('#') > 0)
-      {
-        var parts = pathStr.split('#');
-        elem = '#' + parts[1];
-        var callback = function(){
-          scrollToElement(elem);
-        }
-        if (parts[0] == window.location.pathname){
-          callback();
-        } else {
-          fetchPage(pathStr, callback);
-        }
-      }
-      else
-      {
-        fetchPage(pathStr);
-      }
-      return false;
-    })
-  })
-  app.start();
-  formatTimes();
-  updateHeader(window.location.pathname);
 });
-</script>
 
-<script>
-window.scrollback = {
-streams:["hackerspacesg"],
-        theme: 'light',
-        ticker: true,
-        minimize: true
-};
+(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-/***** don't edit below *****/
-(function(d,s,h,e){e=d.createElement(s);e.async=1;
- e.src=h+'/client.min.js';scrollback.host=h;
- d.getElementsByTagName(s)[0].parentNode.appendChild(e);}
- (document,'script',location.protocol+'//scrollback.io'));
-</script>
-
-<script type="text/javascript">
-var _gaq = _gaq || [];
-_gaq.push(['_setAccount', 'UA-11667249-1']);
-_gaq.push(['_trackPageview']);
-
-(function() {
- var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
- ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
- var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
- })();
+ga('create', 'UA-11667249-1', 'auto');
+ga('send', 'pageview');
 </script>
 
 </body>


### PR DESCRIPTION
scrollback.io and davis is slowing down the site. This is especially apparent on the mobile site. This is a purge of it to make the site faster.

We have tried scrollback.io over the last year. I for one think it has brought zero utility. There are better Web logging applications, e.g. https://botbot.me/ There are better Web IRC clients https://news.ycombinator.com/item?id=8285832

google analytics was removed too since this is the older slower method and should be probably using its new Universal API or just use the server logs, e.g. with http://goaccess.io/

I also took the liberty of updating jquery. Though we should probably replace jquery with the even saner http://zeptojs.com/
