### PR TITLE
Atomically replace the output directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-output/
+output*
 
 node_modules/

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,22 @@
-all: clean
+all:
 	npm install
 	node bin/newevents.js
 	punch g
 
+        # atomically replace output symlink
+	ln -fsT output-new output-lnk
+	mv -T output-lnk output
+
+        # update output-current
+	rsync --delete -a output-new/ output-current/
+
+	# atomically replace output symlink
+	ln -fsT output-current output-lnk
+	mv -T output-lnk output
+	rm -rf output-new
+
 clean:
-	rm -rf output
+	rm -rf output*
 
 deploy: all
 	# Publishing to http://hackerspace.sg.s3-website-ap-southeast-1.amazonaws.com/

--- a/bin/htaccess.js
+++ b/bin/htaccess.js
@@ -8,7 +8,7 @@ module.exports = {
 
 		// Empty path means it's the last thing it does
 		if (!path) {
-			fs.createReadStream('htaccess').pipe(fs.createWriteStream('output/.htaccess'));
+			fs.createReadStream('htaccess').pipe(fs.createWriteStream('output-new/.htaccess'));
 		}
 
 		return callback();

--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
 	"template_dir": "templates",
 	"content_dir": "contents",
-	"output_dir": "output",
+	"output_dir": "output-new",
 
 	"server": {
 		"port": 9009


### PR DESCRIPTION
The old method of removing output/ completely before regenerating it leaves a
small window period of 404s. This eliminates this window period entirely.
