### PR TITLE
Don't set modification times during rsync

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ all:
 	mv -T output-lnk output
 
 	# update output-current
-	rsync --delete -a output-new/ output-current/
+	rsync --delete -a --no-times output-new/ output-current/
 
 	# atomically replace output symlink
 	ln -fsT output-current output-lnk


### PR DESCRIPTION
Setting modification times requires uid == owner_id, which doesn't work when
multiple users deploy under their own monikers.
