### PR TITLE
Fixed Netlify redirects

### DIFF
--- a/redirects
+++ b/redirects
@@ -1,13 +1,13 @@
 /*  https://hackerspace.sg/:splat  301!
 
 /calendar/hackerspacesg-events https://hackerspace.sg/calendar 301
-/calendar/geektechdevdesign-events 404
+/calendar/geektechdevdesign-events / 404
 /calendar/rojak-calendar https://hackerspace.sg/calendar 301
 /readme-txt/membership/ https://hackerspace.sg/membership 301
-/intertubes/ 404
+/intertubes/ / 404
 /readme-txt/donations/ https://hackerspace.sg/membership 301
 /about-us/ https://hackerspace.sg/about 301
 /social/location/ https://hackerspace.sg/location 301
 /chat https://webchat.freenode.net/?channels=hackerspacesg 302
-/feed 404
-/rss.xml 404
+/feed / 404
+/rss.xml / 404

--- a/redirects
+++ b/redirects
@@ -1,3 +1,9 @@
+# This file is named 'redirects' because Punch doesn't recognise files
+# starting with an underscore.
+#
+# Netlify redirect documentation is available here:
+# https://www.netlify.com/docs/redirects/
+
 /*  https://hackerspace.sg/:splat  301!
 
 /calendar/hackerspacesg-events https://hackerspace.sg/calendar 301

--- a/redirects
+++ b/redirects
@@ -7,13 +7,13 @@
 http://hackerspace.sg/*  https://hackerspace.sg/:splat  301!
 
 /calendar/hackerspacesg-events https://hackerspace.sg/calendar 301
-/calendar/geektechdevdesign-events / 404
+/calendar/geektechdevdesign-events /404.html 404
 /calendar/rojak-calendar https://hackerspace.sg/calendar 301
 /readme-txt/membership/ https://hackerspace.sg/membership 301
-/intertubes/ / 404
+/intertubes/ /404.html 404
 /readme-txt/donations/ https://hackerspace.sg/membership 301
 /about-us/ https://hackerspace.sg/about 301
 /social/location/ https://hackerspace.sg/location 301
 /chat https://webchat.freenode.net/?channels=hackerspacesg 302
-/feed / 404
-/rss.xml / 404
+/feed /404.html 404
+/rss.xml /404.html 404

--- a/redirects
+++ b/redirects
@@ -4,7 +4,7 @@
 # Netlify redirect documentation is available here:
 # https://www.netlify.com/docs/redirects/
 
-/*  https://hackerspace.sg/:splat  301!
+http://hackerspace.sg/*  https://hackerspace.sg/:splat  301!
 
 /calendar/hackerspacesg-events https://hackerspace.sg/calendar 301
 /calendar/geektechdevdesign-events / 404


### PR DESCRIPTION
https://hackerspace.sg/chat should work now.

https://5a0dc7b1a6188f1f44dcc022--hsg.netlify.com/chat does work, anyway.